### PR TITLE
Scaled back type highlighting

### DIFF
--- a/syntax/zenc.vim
+++ b/syntax/zenc.vim
@@ -28,6 +28,7 @@ syn keyword zencKeyword
     \ for
     \ guard
     \ if
+    \ impl
     \ import
     \ in
     \ let
@@ -39,18 +40,14 @@ syn keyword zencKeyword
     \ println
     \ ref
     \ return
+    \ struct
     \ test
+    \ trait
     \ union
     \ unless
     \ use
     \ volatile
     \ while
-
-syn keyword zencContainedKeyword contained
-    \ for
-    \ impl
-    \ struct
-    \ trait
 
 syn keyword zencDecoratorName contained transparent
     \ align
@@ -76,44 +73,45 @@ syn keyword zencDecoratorName contained transparent
     \ unused
     \ weak
 
-" Currently commented out in favor of coloring contexts in which types occur.
-" The advantage of the above approach is catching custom types, but the
-" disadvantage is that capturing the context required to do this is a pain
-" with regex-based matching.
-"syn keyword zencType
-"    \ bool
-"    \ byte
-"    \ char
-"    \ double
-"    \ f32 f64
-"    \ float
-"    \ i8 i16 i32 i64 i128
-"    \ int
-"    \ int8_t int16_t int32_t int64_t
-"    \ int_fast8_t int_fast16_t int_fast32_t int_fast64_t
-"    \ int_least8_t int_least16_t int_least32_t int_least64_t
-"    \ intmax_t
-"    \ intptr_t
-"    \ isize
-"    \ long
-"    \ max_align_t
-"    \ nullptr_t
-"    \ ptrdiff_t
-"    \ short
-"    \ signed
-"    \ size_t
-"    \ string
-"    \ u0
-"    \ u8 u16 u32 u64 u128
-"    \ uint
-"    \ uint8_t uint16_t uint32_t uint64_t
-"    \ uint_fast8_t uint_fast16_t uint_fast32_t uint_fast64_t
-"    \ uint_least8_t uint_least16_t uint_least32_t uint_least64_t
-"    \ uintmax_t
-"    \ uintptr_t
-"    \ usize
-"    \ unsigned
-"    \ void
+" Currently, only built-in types will be highlighted.
+" If we wanted to properly support highlighting of custom types in all
+" contexts in which they occur, that would complicate this plugin quite a bit.
+" That functionality is more within the purview of a proper parser like
+" Treesitter.
+syn keyword zencType
+    \ bool
+    \ byte
+    \ char
+    \ double
+    \ f32 f64
+    \ float
+    \ i8 i16 i32 i64 i128
+    \ int
+    \ int8_t int16_t int32_t int64_t
+    \ int_fast8_t int_fast16_t int_fast32_t int_fast64_t
+    \ int_least8_t int_least16_t int_least32_t int_least64_t
+    \ intmax_t
+    \ intptr_t
+    \ isize
+    \ long
+    \ max_align_t
+    \ nullptr_t
+    \ ptrdiff_t
+    \ short
+    \ signed
+    \ size_t
+    \ string
+    \ u0
+    \ u8 u16 u32 u64 u128
+    \ uint
+    \ uint8_t uint16_t uint32_t uint64_t
+    \ uint_fast8_t uint_fast16_t uint_fast32_t uint_fast64_t
+    \ uint_least8_t uint_least16_t uint_least32_t uint_least64_t
+    \ uintmax_t
+    \ uintptr_t
+    \ usize
+    \ unsigned
+    \ void
 
 syn keyword zencConstant
     \ true
@@ -121,13 +119,7 @@ syn keyword zencConstant
 
 syn match zencOperator /\v(\=|\.|\+|-|\*|\/|\%|\=\=|!=|<|>|<=|>=|&|\||\^|!|\~|\[|\])/
 
-syn match zencContainedOperator /=/
-
-syn match zencDelimiter /\v(;|\(|\)|,|\{|\}|->)/
-
-syn match zencContainedDelimiter /\v(\(|,)/
-
-syn match zencColon contained /:/
+syn match zencDelimiter /\v(;|:|\(|\)|,|\{|\}|->)/
 
 syn region zencString oneline start=/"/ skip=/\\"/ end=/"/
 
@@ -135,33 +127,16 @@ syn match zencNumber /\v-?(\d+|\d*\.?\d+)/
 
 syn match zencIdentifier /\v[A-Za-z_]\w*/
 
-" Match type name or trait name in declaration.
-syn match zencType contains=zencContainedKeyword /\v(struct|trait)\s+[A-Za-z_](\w|[<>])*/
-
-" Match type and trait names in impl declaration.
-syn match zencType contains=zencContainedKeyword /\vimpl\s+[A-Za-z_](\w|[<>])*(\s+for\s+[A-Za-z_](\w|[<>])*)?/
-
-" Match type name in struct initializer (works in assignment and arg passing
-" contexts).
-syn match zencType contains=zencContainedDelimiter,zencContainedOperator /\v([^\=!<>]\=|\(|,)\s*[A-Za-z_](\w|[<>])*\ze\s*\{/
-
-" Match type in struct field type specifier
-syn match zencType contains=zencColon /\v:\s*([A-Za-z_](\w|[<>])*(\s+[A-Za-z_](\w|[<>])*)?|fn\**\(.*\))\ze\s*;/
-
-" Match type in let binding
-syn match zencType contains=zencColon /\v:\s*([A-Za-z_](\w|[<>])*(\s+[A-Za-z_](\w|[<>])*)?|fn\**\(.*\))\ze\s*\=/
-
 syn match zencFunctionName /\v[A-Za-z_]\w*\ze\(/
+
+syn match zencDecorator contains=zencDecoratorName /\v\@\w+/
 
 syn match zencEllipsis /\v\.\.\./
 
 syn match zencComment /\v\/\/.*/
 
-syn match zencDecorator contains=zencDecoratorName /\v\@\w+/
-
 hi def link zencComment Comment
 hi def link zencKeyword Statement
-hi def link zencContainedKeyword Statement
 hi def link zencDecorator Statement
 hi def link zencType Type
 hi def link zencConstant Constant
@@ -170,10 +145,7 @@ hi def link zencIdentifier Identifier
 hi def link zencFunctionName Function
 hi def link zencNumber Number
 hi def link zencOperator Operator
-hi def link zencContainedOperator Operator
 hi def link zencDelimiter Delimiter
-hi def link zencContainedDelimiter Delimiter
-hi def link zencColon Delimiter
 hi def link zencEllipsis Special
 
 let b:current_syntax = "zenc"


### PR DESCRIPTION
This commit removes context-based highlighting for types, instead opting to only highlight built-in types.

Context-aware highlighting for custom types is more within the purview of Treesitter/LSP than vim's regex-based parsing.