### PR TITLE
Added custom indentation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Zen-C.vim
 
-This is a syntax highlighting plugin for the [Zen C](https://github.com/z-libs/Zen-C) programming language, supporting [Vim](https://www.vim.org/) and [Neovim](https://neovim.io/).
+This is a [Vim](https://www.vim.org/)/[Neovim](https://neovim.io/) plugin providing syntax highlighting and smart indentation for the [Zen C](https://github.com/z-libs/Zen-C) programming language.
 
-NOTE: This plugin should work fine for most Zen C code that you'll write/encounter, but there may still be unhandled edge cases. Please open an issue for any broken syntax highlighting you encounter.
+NOTE: This plugin should work fine for most Zen C code that you'll write/encounter, but there may still be unhandled edge cases. Please open an issue for any broken syntax highlighting or indentation that you encounter.
 
 ### Installation
 
@@ -30,7 +30,7 @@ git clone https://github.com/davidscholberg/Zen-C.vim.git ~/.local/share/nvim/si
 
 ### Configuration
 
-In addition to syntax highlighting, this plugin sets a few convenience options related to comment editing/formatting. To ensure these options are loaded, make sure the following options are set in your config (some or all of these may be enabled by default, but it won't hurt to explicitly enable them regardless).
+To take advantage of the smart indentation features that this plugin provides, make sure the following options are set in your config (some or all of these may be enabled by default, but it won't hurt to explicitly enable them regardless).
 
 Vim:
 

--- a/indent/zenc.vim
+++ b/indent/zenc.vim
@@ -3,6 +3,140 @@ if exists("b:did_indent")
 endif
 
 let b:did_indent = 1
-let b:undo_indent = "setlocal cindent<"
+let b:undo_indent = "setlocal indentexpr< indentkeys< lisp<"
 
-setlocal cindent
+setlocal nolisp
+
+" Same as default except we remove `:` so that typing a colon doesn't reindent
+" the line.
+setlocal indentkeys=0{,0},0),0],0#,!^F,o,O,e
+
+setlocal indentexpr=GetZencIndent()
+
+" Find the first line number of a multi-line escaped line (i.e. lines with
+" trailing backslashes).
+function s:FindFirstEscapedLine(lnum)
+    let cur_lnum = a:lnum
+
+    while cur_lnum > 0
+        if getline(cur_lnum) !~ '\v.+\\$'
+            return cur_lnum + 1
+        endif
+        let cur_lnum -= 1
+    endwhile
+
+    return 1
+endfunction
+
+" Return the first previous non-blank line that is not a macro or part of an
+" escaped block.
+function s:PrevNonBlankSmart(lnum)
+    if a:lnum == 1
+        return 1
+    endif
+
+    let cur_lnum = a:lnum
+
+    while cur_lnum > 0
+        if getline(cur_lnum - 1) =~ '\v.+\\$'
+            let cur_lnum = prevnonblank(s:FindFirstEscapedLine(cur_lnum - 2) - 1)
+        elseif getline(cur_lnum) =~ '\v^#.*'
+            let cur_lnum = prevnonblank(cur_lnum - 1)
+        else
+            return cur_lnum
+        endif
+
+        if cur_lnum == 1
+            return 1
+        endif
+    endwhile
+
+    return cur_lnum
+endfunction
+
+" Tell if given line number is within a multiline comment.
+function s:InMultilineComment(lnum)
+    let cur_lnum = a:lnum
+
+    while cur_lnum > 0
+        let cur_line = getline(cur_lnum)
+
+        if cur_line =~ '\v^\s+\*($|[^\/](.*\*\/)@!.*)'
+            let cur_lnum -= 1
+            continue
+        endif
+
+        if cur_line =~ '\v^\s*\/\*(.*\*\/)@!.*'
+            return v:true
+        endif
+
+        return v:false
+    endwhile
+
+    return v:false
+endfunction
+
+" Normalizes the indentation of a line down to the nearest multiple of
+" shiftwidth().
+function s:IndentSmart(lnum)
+    let cur_indent = indent(a:lnum)
+    return cur_indent - (cur_indent % shiftwidth())
+endfunction
+
+" Simple indent function that handles nesting of {} [] and () pairs,
+" multi-line comments, macros, and lines with escaped newlines.
+function GetZencIndent()
+    let cur_line = getline(v:lnum)
+
+    if cur_line =~ '\v^\s*#.*'
+        " preprocessor macro
+        return 0
+    endif
+
+    let prev_lnum = prevnonblank(v:lnum - 1)
+    if prev_lnum == 0
+        return 0
+    endif
+
+    let prev_indent = s:IndentSmart(prev_lnum)
+    let prev_line = getline(prev_lnum)
+
+    if s:InMultilineComment(prev_lnum)
+        "continuation of multiline comment
+        return prev_indent + 1
+    endif
+
+    if prev_line =~ '\v.+\\$'
+        "continuation of escaped newline
+        if s:FindFirstEscapedLine(prev_lnum - 1) == prev_lnum
+            return prev_indent + shiftwidth()
+        endif
+        return prev_indent
+    endif
+
+    " skip over escaped blocks
+    let prev_smart_lnum = s:PrevNonBlankSmart(prev_lnum)
+    if prev_smart_lnum == 0
+        return 0
+    endif
+
+    let prev_smart_indent = s:IndentSmart(prev_smart_lnum)
+    let prev_smart_line = getline(prev_smart_lnum)
+
+    if prev_smart_line =~ '\v.*[{([]\s*(\/\/.*|\/\*.*\*\/\s*)?$'
+        if cur_line =~ '\v^\s*[})\]].*'
+            " current line closes new block
+            return prev_smart_indent
+        endif
+        " increase indent for new block
+        return prev_smart_indent + shiftwidth()
+    endif
+
+    if cur_line =~ '\v^\s*[})\]].*'
+        " decrease indent for closed block
+        return prev_smart_indent - shiftwidth()
+    endif
+
+    " chill with the previous indent level
+    return prev_smart_indent
+endfunction


### PR DESCRIPTION
The new indentation function mostly does what cindent() does except it won't re-indent lines with a colon in them (which is important for a language where the separator between a var name and a type is a colon).